### PR TITLE
Fixed Listing Generation in Macros

### DIFF
--- a/src/asm.rs
+++ b/src/asm.rs
@@ -76,16 +76,17 @@ impl Assembler {
 
         if let Some(listing) = self.listing.as_mut() {
             let index = self.listing_index.as_mut().unwrap();
-            if index
-                .insert((line.path.clone(), line.line_num), listing.len())
-                .is_some()
+            if let std::collections::hash_map::Entry::Vacant(e) =
+                index.entry((line.path.clone(), line.line_num))
             {
-                panic!("saw the same line from the same file twice")
+                e.insert(listing.len());
+                listing.push(format!(
+                    "{:06} {:04X}        {}",
+                    line.line_num, self.pc, line.text
+                ));
+            } else {
+                // skip listing on multiple sights, such as in macros
             }
-            listing.push(format!(
-                "{:06} {:04X}        {}",
-                line.line_num, self.pc, line.text
-            ));
         }
 
         if !*self.if_stack.last().unwrap_or(&true) {

--- a/src/mac.rs
+++ b/src/mac.rs
@@ -100,7 +100,11 @@ impl MacUsage {
         for (i, arg) in self.args.iter().enumerate() {
             s = s.replace(&format!(r"\{}", i + 1), arg);
         }
-        Line::new(&s, &line.path, line.line_num)
+        Line::new(
+            &s,
+            &self.referenced_line.path,
+            self.referenced_line.line_num,
+        )
     }
 
     /// Get a macro source.


### PR DESCRIPTION
The listing generator presently crashes if it sees the same line more than once, like in a macro expansion. I've changed that to ignoring.